### PR TITLE
AB#1229: Fix "Could not parse import/exports with acorn" issue with index.md files in Docusaurus and update System.Text.Json

### DIFF
--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using System.Reflection;
 using Markdown;
 using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.DependencyModel;
 using XMLDoc2Markdown.Docusaurus;
 using XMLDoc2Markdown.Utils;
+
 
 namespace XMLDoc2Markdown;
 
@@ -18,6 +20,55 @@ internal class Program
         {
             Name = "xmldoc2md"
         };
+        
+        // var deps = DependencyContext.Default;
+        // var libraries = deps.CompileLibraries;
+        //
+        // foreach (var library in libraries)
+        // {
+        //     if (library.Name.Contains("Microsoft."))
+        //     {
+        //         Console.WriteLine($"Library: {library.Name}");
+        //         Console.WriteLine($"  Type: {library.Type}");
+        //         Console.WriteLine($"  Version: {library.Version}");
+        //
+        //         // Print assembly names
+        //         Console.WriteLine("  Assemblies:");
+        //         foreach (var assembly in library.Assemblies)
+        //         {
+        //             Console.WriteLine($"    {assembly}");
+        //         }
+        //
+        //         // Try to resolve reference paths
+        //         var paths = library.ResolveReferencePaths();
+        //         if (paths.Any())
+        //         {
+        //             Console.WriteLine("  Reference Paths:");
+        //             foreach (var path in paths)
+        //             {
+        //                 Console.WriteLine($"    {path}");
+        //             }
+        //         }
+        //         // Print dependencies
+        //         if (library.Dependencies.Any())
+        //         {
+        //             Console.WriteLine("  Dependencies:");
+        //             foreach (var dependency in library.Dependencies)
+        //             {
+        //                 Console.WriteLine($"    {dependency.Name} ({dependency.Version})");
+        //             }
+        //         }
+        //
+        //         Console.WriteLine(); // Empty line for readability
+        //     }
+        // }
+        //
+        // var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+        // foreach (var assembly in loadedAssemblies)
+        // {
+        //     Console.WriteLine($"Assembly: {assembly.FullName}");
+        //     Console.WriteLine($"Location: {assembly.Location}");
+        // }
 
         app.VersionOption("-v|--version", () =>
         {
@@ -84,7 +135,10 @@ internal class Program
                 Directory.CreateDirectory(@out.ToLower());
             }
 
-            Assembly assembly = new AssemblyLoadContext(src)
+
+            var x = new AssemblyLoadContext(src, true); 
+            
+             Assembly assembly = x
                 .LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(src)));
 
             string assemblyName = assembly.GetName().Name;

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -79,9 +79,9 @@ internal class Program
             int succeeded = 0;
             int failed = 0;
 
-            if (!Directory.Exists(@out))
+            if (!Directory.Exists(@out.ToLower()))
             {
-                Directory.CreateDirectory(@out);
+                Directory.CreateDirectory(@out.ToLower());
             }
 
             Assembly assembly = new AssemblyLoadContext(src)
@@ -107,7 +107,7 @@ internal class Program
                     for (int index = 0; index < relativeFolderPath.Count; index++)
                     {
                         string directory = relativeFolderPath[index];
-                        folderPath = Path.Combine(folderPath, directory);
+                        folderPath = Path.Combine(folderPath, directory).ToLower();
                         if (!Directory.Exists(folderPath))
                         {
                             Directory.CreateDirectory(folderPath);
@@ -130,13 +130,6 @@ internal class Program
 
                 foreach (Type type in namespaceTypes.OrderBy(x => x.Name))
                 {
-                    // exclude delegates
-                    if (typeof(Delegate).IsAssignableFrom(type))
-                    {
-                        continue;
-                    }
-
-                
                     var fileName = type.GetDocsFileName(false);
                     Logger.Info($"  {fileName}.md");
 

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using System.Reflection;
 using Markdown;
 using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.DependencyModel;
 using XMLDoc2Markdown.Docusaurus;
 using XMLDoc2Markdown.Utils;
+
 
 namespace XMLDoc2Markdown;
 
@@ -18,6 +20,55 @@ internal class Program
         {
             Name = "xmldoc2md"
         };
+        
+        // var deps = DependencyContext.Default;
+        // var libraries = deps.CompileLibraries;
+        //
+        // foreach (var library in libraries)
+        // {
+        //     if (library.Name.Contains("Microsoft."))
+        //     {
+        //         Console.WriteLine($"Library: {library.Name}");
+        //         Console.WriteLine($"  Type: {library.Type}");
+        //         Console.WriteLine($"  Version: {library.Version}");
+        //
+        //         // Print assembly names
+        //         Console.WriteLine("  Assemblies:");
+        //         foreach (var assembly in library.Assemblies)
+        //         {
+        //             Console.WriteLine($"    {assembly}");
+        //         }
+        //
+        //         // Try to resolve reference paths
+        //         var paths = library.ResolveReferencePaths();
+        //         if (paths.Any())
+        //         {
+        //             Console.WriteLine("  Reference Paths:");
+        //             foreach (var path in paths)
+        //             {
+        //                 Console.WriteLine($"    {path}");
+        //             }
+        //         }
+        //         // Print dependencies
+        //         if (library.Dependencies.Any())
+        //         {
+        //             Console.WriteLine("  Dependencies:");
+        //             foreach (var dependency in library.Dependencies)
+        //             {
+        //                 Console.WriteLine($"    {dependency.Name} ({dependency.Version})");
+        //             }
+        //         }
+        //
+        //         Console.WriteLine(); // Empty line for readability
+        //     }
+        // }
+        //
+        // var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+        // foreach (var assembly in loadedAssemblies)
+        // {
+        //     Console.WriteLine($"Assembly: {assembly.FullName}");
+        //     Console.WriteLine($"Location: {assembly.Location}");
+        // }
 
         app.VersionOption("-v|--version", () =>
         {
@@ -84,7 +135,10 @@ internal class Program
                 Directory.CreateDirectory(@out);
             }
 
-            Assembly assembly = new AssemblyLoadContext(src)
+
+            var x = new AssemblyLoadContext(src, true); 
+            
+             Assembly assembly = x
                 .LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(src)));
 
             string assemblyName = assembly.GetName().Name;

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -91,8 +91,9 @@ internal class Program
             XmlDocumentation documentation = new(src);
             Logger.Info($"Generation started: Assembly: {assemblyName}");
 
-            IMarkdownDocument indexPage = new MarkdownDocument().AppendHeader(assemblyName, 1);
-
+            IMarkdownDocument indexPage = new MarkdownDocument().AppendParagraph("");
+            indexPage.AppendHeader(assemblyName, 1);
+            
             IEnumerable<Type> types = assembly.GetTypes().Where(type => type.IsPublic);
             IEnumerable<IGrouping<string, Type>> typesByNamespace = types.GroupBy(type => type.Namespace).OrderBy(g => g.Key);
             int subNamespacePos = 0;

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -115,9 +115,9 @@ internal class Program
 
                         if (index == 0)
                         {
-                            DocusaurusSerializer.Serialize(folderPath, new Category{ Label = directory, Position = subNamespacePos++});
+                            DocusaurusSerializer.Serialize(folderPath, new Category{ Label = string.IsNullOrWhiteSpace(directory) ? null : directory, Position = subNamespacePos++});
                         }
-                        else
+                        else if (!string.IsNullOrWhiteSpace(directory))
                         {
                             DocusaurusSerializer.Serialize(folderPath, new Category{ Label = directory});
                         }

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -20,55 +20,6 @@ internal class Program
         {
             Name = "xmldoc2md"
         };
-        
-        // var deps = DependencyContext.Default;
-        // var libraries = deps.CompileLibraries;
-        //
-        // foreach (var library in libraries)
-        // {
-        //     if (library.Name.Contains("Microsoft."))
-        //     {
-        //         Console.WriteLine($"Library: {library.Name}");
-        //         Console.WriteLine($"  Type: {library.Type}");
-        //         Console.WriteLine($"  Version: {library.Version}");
-        //
-        //         // Print assembly names
-        //         Console.WriteLine("  Assemblies:");
-        //         foreach (var assembly in library.Assemblies)
-        //         {
-        //             Console.WriteLine($"    {assembly}");
-        //         }
-        //
-        //         // Try to resolve reference paths
-        //         var paths = library.ResolveReferencePaths();
-        //         if (paths.Any())
-        //         {
-        //             Console.WriteLine("  Reference Paths:");
-        //             foreach (var path in paths)
-        //             {
-        //                 Console.WriteLine($"    {path}");
-        //             }
-        //         }
-        //         // Print dependencies
-        //         if (library.Dependencies.Any())
-        //         {
-        //             Console.WriteLine("  Dependencies:");
-        //             foreach (var dependency in library.Dependencies)
-        //             {
-        //                 Console.WriteLine($"    {dependency.Name} ({dependency.Version})");
-        //             }
-        //         }
-        //
-        //         Console.WriteLine(); // Empty line for readability
-        //     }
-        // }
-        //
-        // var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-        // foreach (var assembly in loadedAssemblies)
-        // {
-        //     Console.WriteLine($"Assembly: {assembly.FullName}");
-        //     Console.WriteLine($"Location: {assembly.Location}");
-        // }
 
         app.VersionOption("-v|--version", () =>
         {

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -131,13 +131,6 @@ internal class Program
 
                 foreach (Type type in namespaceTypes.OrderBy(x => x.Name))
                 {
-                    // exclude delegates
-                    if (typeof(Delegate).IsAssignableFrom(type))
-                    {
-                        continue;
-                    }
-
-                
                     var fileName = type.GetDocsFileName(false);
                     Logger.Info($"  {fileName}.md");
 

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -20,6 +20,55 @@ internal class Program
         {
             Name = "xmldoc2md"
         };
+        
+        // var deps = DependencyContext.Default;
+        // var libraries = deps.CompileLibraries;
+        //
+        // foreach (var library in libraries)
+        // {
+        //     if (library.Name.Contains("Microsoft."))
+        //     {
+        //         Console.WriteLine($"Library: {library.Name}");
+        //         Console.WriteLine($"  Type: {library.Type}");
+        //         Console.WriteLine($"  Version: {library.Version}");
+        //
+        //         // Print assembly names
+        //         Console.WriteLine("  Assemblies:");
+        //         foreach (var assembly in library.Assemblies)
+        //         {
+        //             Console.WriteLine($"    {assembly}");
+        //         }
+        //
+        //         // Try to resolve reference paths
+        //         var paths = library.ResolveReferencePaths();
+        //         if (paths.Any())
+        //         {
+        //             Console.WriteLine("  Reference Paths:");
+        //             foreach (var path in paths)
+        //             {
+        //                 Console.WriteLine($"    {path}");
+        //             }
+        //         }
+        //         // Print dependencies
+        //         if (library.Dependencies.Any())
+        //         {
+        //             Console.WriteLine("  Dependencies:");
+        //             foreach (var dependency in library.Dependencies)
+        //             {
+        //                 Console.WriteLine($"    {dependency.Name} ({dependency.Version})");
+        //             }
+        //         }
+        //
+        //         Console.WriteLine(); // Empty line for readability
+        //     }
+        // }
+        //
+        // var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+        // foreach (var assembly in loadedAssemblies)
+        // {
+        //     Console.WriteLine($"Assembly: {assembly.FullName}");
+        //     Console.WriteLine($"Location: {assembly.Location}");
+        // }
 
         app.VersionOption("-v|--version", () =>
         {

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -79,9 +79,9 @@ internal class Program
             int succeeded = 0;
             int failed = 0;
 
-            if (!Directory.Exists(@out.ToLower()))
+            if (!Directory.Exists(@out))
             {
-                Directory.CreateDirectory(@out.ToLower());
+                Directory.CreateDirectory(@out);
             }
 
             Assembly assembly = new AssemblyLoadContext(src)
@@ -107,7 +107,7 @@ internal class Program
                     for (int index = 0; index < relativeFolderPath.Count; index++)
                     {
                         string directory = relativeFolderPath[index];
-                        folderPath = Path.Combine(folderPath, directory).ToLower();
+                        folderPath = Path.Combine(folderPath, directory.ToLower());
                         if (!Directory.Exists(folderPath))
                         {
                             Directory.CreateDirectory(folderPath);

--- a/src/XMLDoc2Markdown/Utils/AssemblyExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyExtensions.cs
@@ -32,7 +32,7 @@ internal static class AssemblyExtensions
             return null;
         }
 
-        return subNamespace.TrimStart('.');
+        return subNamespace.Substring(0);
     }
     
     internal static IEnumerable<string> GetSubNamespaceParts(this Assembly assembly, string @namespace)
@@ -46,7 +46,7 @@ internal static class AssemblyExtensions
             return new List<string>();
         }
 
-        return subNamespace.Split(".");
+        return subNamespace.Substring(0).Split(".");
     }
     
     internal static string GetRelativeFolderPath(this Assembly assembly, string @namespace)

--- a/src/XMLDoc2Markdown/Utils/AssemblyExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyExtensions.cs
@@ -32,7 +32,7 @@ internal static class AssemblyExtensions
             return null;
         }
 
-        return subNamespace.Substring(1);
+        return subNamespace.Substring(0);
     }
     
     internal static IEnumerable<string> GetSubNamespaceParts(this Assembly assembly, string @namespace)
@@ -46,7 +46,7 @@ internal static class AssemblyExtensions
             return new List<string>();
         }
 
-        return subNamespace.Substring(1).Split(".");
+        return subNamespace.Substring(0).Split(".");
     }
     
     internal static string GetRelativeFolderPath(this Assembly assembly, string @namespace)

--- a/src/XMLDoc2Markdown/Utils/AssemblyExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyExtensions.cs
@@ -32,7 +32,7 @@ internal static class AssemblyExtensions
             return null;
         }
 
-        return subNamespace.Substring(1);
+        return subNamespace.TrimStart('.');
     }
     
     internal static IEnumerable<string> GetSubNamespaceParts(this Assembly assembly, string @namespace)
@@ -46,7 +46,7 @@ internal static class AssemblyExtensions
             return new List<string>();
         }
 
-        return subNamespace.Substring(1).Split(".");
+        return subNamespace.Split(".");
     }
     
     internal static string GetRelativeFolderPath(this Assembly assembly, string @namespace)

--- a/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 namespace XMLDoc2Markdown.Utils;
@@ -23,13 +22,12 @@ internal class AssemblyLoadContext : System.Runtime.Loader.AssemblyLoadContext
 
     private Assembly OnResolving(System.Runtime.Loader.AssemblyLoadContext context, AssemblyName name)
     {
-            string[] possiblePaths = new[]
-            {
+            string[] possiblePaths =
+            [
                 Path.GetDirectoryName(this._pluginPath),
-                //@"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\8.0.8",
-                GetAspNetCoreSharedPath(),
+                PathHelpers.GetAspNetCoreSharedPath(),
                 AppDomain.CurrentDomain.BaseDirectory
-            };
+            ];
 
             foreach (string searchPath in possiblePaths)
             {
@@ -67,42 +65,5 @@ internal class AssemblyLoadContext : System.Runtime.Loader.AssemblyLoadContext
         }
 
         return IntPtr.Zero;
-    }
-    
-    static string GetDotNetRootPath()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),"dotnet");
-        }
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || 
-            RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return "/usr/share/dotnet";
-        }
-
-        throw new PlatformNotSupportedException("Unsupported operating system.");
-    }
-    private static string GetAspNetCoreSharedPath()
-    {
-        string dotnetPath = GetDotNetRootPath();
-        string aspNetPath = Path.Combine(dotnetPath, "shared", "Microsoft.AspNetCore.App");
-        string fullPath = Path.Combine(aspNetPath, GetVersionDirectoryName(aspNetPath));
-        return fullPath;
-    }
-
-    private static string GetVersionDirectoryName(string aspNetPath)
-    {
-        string[] versions = Directory.GetDirectories(aspNetPath, "8.0.*");
-        if (versions.Length == 0)
-        {
-            throw new DirectoryNotFoundException("No directory found starting with 8.0.");
-        }
-
-        Array.Sort(versions);
-        
-        return versions[^1];
- 
     }
 }

--- a/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
@@ -22,12 +22,12 @@ internal class AssemblyLoadContext : System.Runtime.Loader.AssemblyLoadContext
 
     private Assembly OnResolving(System.Runtime.Loader.AssemblyLoadContext context, AssemblyName name)
     {
-            string[] possiblePaths =
-            [
+            string[] possiblePaths = new[]
+            {
                 Path.GetDirectoryName(this._pluginPath),
-                PathHelpers.GetAspNetCoreSharedPath(),
+                @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\8.0.8",
                 AppDomain.CurrentDomain.BaseDirectory
-            ];
+            };
 
             foreach (string searchPath in possiblePaths)
             {

--- a/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 
@@ -6,16 +7,47 @@ namespace XMLDoc2Markdown.Utils;
 
 internal class AssemblyLoadContext : System.Runtime.Loader.AssemblyLoadContext
 {
-    private readonly AssemblyDependencyResolver resolver;
+    private readonly string _pluginPath;
+    private readonly AssemblyDependencyResolver _resolver;
 
-    public AssemblyLoadContext(string pluginPath)
+    public AssemblyLoadContext(string pluginPath, bool isCollectible) : base(Guid.NewGuid().ToString(), isCollectible)
     {
-        this.resolver = new AssemblyDependencyResolver(pluginPath);
+        this._pluginPath = pluginPath;
+        this._resolver = new AssemblyDependencyResolver(pluginPath);
+        
+        this.Resolving += this.OnResolving;
+        
+        
+    }
+
+    private Assembly OnResolving(System.Runtime.Loader.AssemblyLoadContext context, AssemblyName name)
+    {
+            string[] possiblePaths = new[]
+            {
+                Path.GetDirectoryName(this._pluginPath),
+                @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\8.0.8",
+                AppDomain.CurrentDomain.BaseDirectory
+            };
+
+            foreach (string searchPath in possiblePaths)
+            {
+                string filePath = Path.Combine(searchPath, name.Name + ".dll");
+                Console.WriteLine($"Attempting to load: {filePath}");
+
+                if (File.Exists(filePath))
+                {
+                    return context.LoadFromAssemblyPath(filePath);
+                }
+            }
+            
+
+            Console.WriteLine($"Unable to find assembly: {name.FullName}");
+            return null;
     }
 
     protected override Assembly Load(AssemblyName assemblyName)
     {
-        string assemblyPath = this.resolver.ResolveAssemblyToPath(assemblyName);
+        string assemblyPath = this._resolver.ResolveAssemblyToPath(assemblyName);
         if (assemblyPath != null)
         {
             return this.LoadFromAssemblyPath(assemblyPath);
@@ -26,7 +58,7 @@ internal class AssemblyLoadContext : System.Runtime.Loader.AssemblyLoadContext
 
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
     {
-        string libraryPath = this.resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        string libraryPath = this._resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
         if (libraryPath != null)
         {
             return this.LoadUnmanagedDllFromPath(libraryPath);

--- a/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
@@ -73,7 +73,7 @@ internal class AssemblyLoadContext : System.Runtime.Loader.AssemblyLoadContext
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return Environment.ExpandEnvironmentVariables(@"C:\Program Files\dotnet");
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),"dotnet");
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || 

--- a/src/XMLDoc2Markdown/Utils/PathHelpers.cs
+++ b/src/XMLDoc2Markdown/Utils/PathHelpers.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace XMLDoc2Markdown.Utils;
+
+internal static class PathHelpers
+{
+    private static string GetDotNetRootPath()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),"dotnet");
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || 
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "/usr/share/dotnet";
+        }
+
+        throw new PlatformNotSupportedException("Unsupported operating system.");
+    }
+
+    internal static string GetAspNetCoreSharedPath()
+    {
+        string dotnetPath = GetDotNetRootPath();
+        string aspNetPath = Path.Combine(dotnetPath, "shared", "Microsoft.AspNetCore.App");
+        string fullPath = Path.Combine(aspNetPath, GetVersionDirectoryName(aspNetPath));
+        return fullPath;
+    }
+
+    private static string GetVersionDirectoryName(string aspNetPath)
+    {
+        string[] versions = Directory.GetDirectories(aspNetPath, "8.0.*");
+        if (versions.Length == 0)
+        {
+            throw new DirectoryNotFoundException("No directory found starting with 8.0.");
+        }
+
+        Array.Sort(versions);
+        
+        return versions[^1];
+ 
+    }
+}

--- a/src/XMLDoc2Markdown/Utils/TypeExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/TypeExtensions.cs
@@ -186,7 +186,7 @@ internal static class TypeExtensions
         string ret = "";
         if (referenceTypeFolder != currentTypeFolder)
         {
-            var y = currentTypeFolder?.Split("/").Length ?? 0;
+            var y = currentTypeFolder?.Split("/").Where(x => !string.IsNullOrWhiteSpace(x)).ToArray().Length ?? 0;
             for (int i = 0; i < y; i++)
             {
                 ret += "../";

--- a/src/XMLDoc2Markdown/XMLDoc2Markdown.csproj
+++ b/src/XMLDoc2Markdown/XMLDoc2Markdown.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="MarkdownBuilder" Version="0.2.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/XMLDoc2Markdown/XMLDoc2Markdown.csproj
+++ b/src/XMLDoc2Markdown/XMLDoc2Markdown.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add an AppendParagraph() before the AppendHeader() to ensure newlines before Markdown Header which removes the "Could not parse import/exports with acorn" issue. Additionally Updated the System.Text.Json Package to version 8.0.4 to mitigate security risk.