### PR TITLE
AB#4040: Fix GetDisplayName for nested types of generic outer

### DIFF
--- a/src/XMLDoc2Markdown/Utils/TypeExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/TypeExtensions.cs
@@ -144,7 +144,13 @@ internal static class TypeExtensions
 
         if (genericParams.Length > 0)
         {
-            name = name[..name.IndexOf('`')];
+            // Nested types of a generic outer (e.g. Dictionary<TKey,TValue>+KeyCollection)
+            // inherit GenericTypeArguments from the outer but have no backtick in their own name.
+            int backtickIndex = name.IndexOf('`');
+            if (backtickIndex >= 0)
+            {
+                name = name[..backtickIndex];
+            }
             name += $"<{string.Join(", ", genericParams.Select(t => t.GetDisplayName(simplifyName)))}>";
         }
 


### PR DESCRIPTION
## Summary

`mmxmldoc2md 3.1.35` throws `ArgumentOutOfRangeException` when generating documentation for any top-level `public class` that subclasses a generic BCL collection (e.g. `Dictionary<TKey,TValue>`). The class itself is skipped, but cross-reference links to it are still emitted by other types — producing broken Markdown links in the output.

## Root cause

`Utils/TypeExtensions.cs:147` performs ``name = name[..name.IndexOf('`')]`` under `if (genericParams.Length > 0)`. For nested types of a generic outer (e.g. `Dictionary<TKey,TValue>+KeyCollection`, `+ValueCollection`), `TypeInfo.GenericTypeArguments.Length > 0` (inherited from the outer) but `Type.Name` has no backtick of its own - ``IndexOf('`')`` returns -1 and `Substring` throws.

The exception bubbles up from `PropertyInfoExtensions.GetSignature` → `WriteMembersDocumentation`, aborting the page generation for the affected type while leaving emitted cross-reference links pointing at the missing file.

## Stack trace

System.ArgumentOutOfRangeException: length ('-1') must be a non-negative value. (Parameter 'length')
   at System.String.Substring(Int32 startIndex, Int32 length)
   at XMLDoc2Markdown.Utils.TypeExtensions.GetDisplayName(Type type, Boolean simplifyName) in TypeExtensions.cs:line 147
   at XMLDoc2Markdown.Utils.PropertyInfoExtensions.GetSignature(PropertyInfo propertyInfo, Boolean full) in PropertyInfoExtensions.cs:line 43
   at XMLDoc2Markdown.Utils.MemberInfoExtensions.GetSignature(MemberInfo memberInfo, Boolean full) in MemberInfoExtensions.cs:line 28
   at XMLDoc2Markdown.TypeDocumentation.WriteMemberInfoSignature(MemberInfo memberInfo) in TypeDocumentation.cs:line 340
   at XMLDoc2Markdown.TypeDocumentation.WriteMembersDocumentation(IEnumerable members) in TypeDocumentation.cs:line 377
   at XMLDoc2Markdown.TypeDocumentation.ToString() in TypeDocumentation.cs:line 75

## Fix

Guard the `Substring` call with a non-negative check on the backtick lookup. If no backtick is present in `Type.Name` (nested type of generic outer), keep the name as-is and append the inherited generic arguments.