### PR TITLE
Fix: render internal types and out/ref generic params as plain text (no dangling links)

### DIFF
--- a/src/XMLDoc2Markdown/Utils/TypeExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/TypeExtensions.cs
@@ -244,7 +244,11 @@ internal static class TypeExtensions
             return true;
         }
 
-        if (type.IsArray)
+        // out/ref parameters are ByRef wrappers (T&), arrays are T[] — in both cases the
+        // generic-ness lives on the element type, so unwrap one level before checking.
+        // Without the ByRef case an "out T value" parameter is mistaken for a real type and
+        // linked to a non-existent page (e.g. [T](./t.md)).
+        if (type.IsArray || type.IsByRef)
         {
             var elementType = type.GetElementType();
             if (elementType != null)
@@ -293,7 +297,9 @@ internal static class TypeExtensions
                 return new MarkdownLink(text, type.GetMSDocsUrl());
             }
 
-            if (type.Assembly == assembly)
+            // Only public types get a generated page (see Program.cs: GetTypes().Where(t => t.IsPublic)).
+            // Linking an internal (or nested) type produces a dangling link, so render those as plain text.
+            if (type.Assembly == assembly && type.IsPublic)
             {
                 return new MarkdownLink(text, type.GetInternalDocsUrl(currentNamespace, noExtension, noPrefix));
             }


### PR DESCRIPTION
## Problem

`GetDocsLink` (`Utils/TypeExtensions.cs`) emitted relative Markdown links to type pages that are never generated, producing **dangling links** that break strict downstream Markdown builds (e.g. Docusaurus `onBrokenMarkdownLinks: 'throw'`):

- **Internal types** — `GetDocsLink` linked *any* type in the documented assembly, but `Program.cs` only generates pages for `type.IsPublic`. Internal types (e.g. `DataOverlay`, `IReadSource`, `ElementSource`, `LayeredSource`, `JsonPathWalker`) were linked to non-existent pages.
- **`out` / `ref` generic params** — `IsGenericParameter()` unwrapped `Array` but not `ByRef`, so an `out T` / `ref T` parameter (a `T&` type) was mistaken for a real same-assembly type and linked as `[T](./t.md)`.

This surfaced when `Meshmakers.Octo.Sdk.Common`'s System.Text.Json migration introduced `TryGet<T>(string, out T)` and internal seam types — and has been breaking the `octo-documentation` Docusaurus build since the 2026-06-03 apiReference regeneration.

## Fix

Two minimal guards in `Utils/TypeExtensions.cs`:

- `IsGenericParameter()` — also unwrap `ByRef` (`out` / `ref`) before checking the element type.
- `GetDocsLink()` — only emit the same-assembly link when `type.IsPublic`, matching `Program.cs`'s page-generation predicate (`GetTypes().Where(t => t.IsPublic)`). Non-public types render as plain text.

## Verification (repro-based)

Generated docs for `Meshmakers.Octo.Sdk.Common.dll` (net10.0):

| | relative `.md` links | dangling |
|---|---|---|
| Baseline (master / 3.1.36) | 996 | **9** |
| Patched | 987 | **0** |

The 9 dangling refs (`t`, `dataoverlay`, `ireadsource`, `elementsource`, `layeredsource`, `jsonpathwalker`) now render as plain text; the other 987 valid links are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
